### PR TITLE
Support multiply.

### DIFF
--- a/build/Doxyfile
+++ b/build/Doxyfile
@@ -778,7 +778,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters

--- a/build/cppcheck_suppression.txt
+++ b/build/cppcheck_suppression.txt
@@ -1,2 +1,3 @@
 missingInclude
 unmatchedSuppression
+unusedFunction

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -322,6 +322,36 @@ class fixed_t {
   FromInternalType(internal_int_t src);
 };
 
+/// Function to multiply fixed_t with keeping precision.
+///
+/// Result fixed_t<> type is not same as both lhs and rhs type.
+/// That type has enough precision to keep multiply result,
+/// twice bit width to kee[ fixed point data
+/// and bits width to assign for keeping decimal parts will be widen.
+///
+/// @tparam internal_int_t Internal integral type to hold fixed point number
+/// @tparam l_Q            Bits width for decimal part of lhs
+/// @tparam r_Q            Bits width for decimal part of rhs
+///
+/// @param lhs Left hand side value to multiply
+/// @param rhs Right hand side value to multiply
+///
+/// @return Multiply result
+template <typename internal_int_t, std::size_t l_Q, std::size_t r_Q>
+auto fixed_mul(fixed_t<internal_int_t, l_Q> lhs,
+               const fixed_t<internal_int_t, r_Q> rhs)
+    -> fixed_t<impl::wider_int_t<internal_int_t>, l_Q + r_Q> {
+  using wider_int_t = impl::wider_int_t<internal_int_t>;
+  const auto lhs_wide = static_cast<wider_int_t>(lhs.fixed_point_);
+  const auto rhs_wide = static_cast<wider_int_t>(rhs.fixed_point_);
+
+  using result_t = fixed_t<wider_int_t, l_Q + r_Q>;
+  result_t result;
+  result.fixed_point_ = lhs_wide * rhs_wide;
+
+  return result;
+}
+
 }  // namespace fixedpointnumber
 
 #include "fixedpointnumber_conversion-priv.h"

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -165,6 +165,17 @@ class fixed_t {
     return *this;
   }
 
+  /// Compound assignment operator*=.
+  ///
+  /// @param[in] rhs Value to multiply into this instance
+  ///
+  /// @return Reference to this instance multiplied rhs into.
+  fixed_t& operator*=(const fixed_t& rhs) {
+    const fixed_t result = fixed_mul(*this, rhs);
+    *this = static_cast<decltype(*this)>(result);
+    return *this;
+  }
+
   /// Comparison operator, equal.
   ///
   /// @param[in] lhs Left hand side value which is compared to
@@ -350,6 +361,22 @@ auto fixed_mul(fixed_t<internal_int_t, l_Q> lhs,
   result.fixed_point_ = lhs_wide * rhs_wide;
 
   return result;
+}
+
+/// Multiply operator.
+///
+/// This operator keeps same type as lhs and rhs after multiply.
+///
+/// @tparam internal_int_t Internal integral type to hold fixed point number
+/// @tparam Q              Bits width for decimal part
+///
+/// @return Multiply result
+///
+/// @note Precision of multiply result can be lossy in this operator
+template <typename internal_int_t, std::size_t Q>
+fixed_t<internal_int_t, Q> operator*(fixed_t<internal_int_t, Q> lhs,
+                                     const fixed_t<internal_int_t, Q>& rhs) {
+  return static_cast<fixed_t<internal_int_t, Q>>(fixed_mul(lhs, rhs));
 }
 
 }  // namespace fixedpointnumber

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -24,6 +24,8 @@
 
 #define FIXEDPOINTNUMBER_INTERNAL
 
+#include "fixedpointnumber_wider_int.h"
+
 namespace fixedpointnumber {
 
 /// Type for fixed point number.

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Minoru Sekine
+// Copyright 2019,2020 Minoru Sekine
 //
 // This file is part of libfixedpointnumber.
 //
@@ -28,9 +28,9 @@ namespace fixedpointnumber {
 
 /// Type for fixed point number.
 ///
-/// @tparam IntType Internal integral type to hold fixed point number
-/// @tparam Q       Bits width for decimal part
-template <typename IntType, std::size_t Q>
+/// @tparam internal_int_t Internal integral type to hold fixed point number
+/// @tparam Q              Bits width for decimal part
+template <typename internal_int_t, std::size_t Q>
 class fixed_t {
  public:
   /// Default constructor.
@@ -53,7 +53,7 @@ class fixed_t {
   /// @param[in] src Value to construct from
   template <typename SrcType>
   constexpr explicit fixed_t(SrcType src)
-      : fixed_point_(ToIntType<SrcType>(src)) {
+      : fixed_point_(ToInternalType<SrcType>(src)) {
   }
 
   /// Construction from fixed_t which has another template param.
@@ -64,7 +64,7 @@ class fixed_t {
   /// @param[in] src fixed_t to construct from
   template <typename SrcIntType, std::size_t SrcQ>
   constexpr explicit fixed_t(const fixed_t<SrcIntType, SrcQ>& src)
-      : fixed_point_(ToIntType<SrcIntType, SrcQ>(src)) {
+      : fixed_point_(ToInternalType<SrcIntType, SrcQ>(src)) {
   }
 
   /// Cast operator to specified integral or floating-point types.
@@ -74,7 +74,7 @@ class fixed_t {
   /// @return Casted DestType value converted from holding fixed point number.
   template <typename DestType>
   constexpr operator DestType() const {
-    return FromIntType<DestType>(fixed_point_);
+    return FromInternalType<DestType>(fixed_point_);
   }
 
   /// Copy operator.
@@ -101,9 +101,9 @@ class fixed_t {
     //   fixed_point_ += rhs.fixed_point_;
     // is not valid on some environments.
     // Because implicit integer promotion makes
-    // from int to short (if IntType is short) cast implicitly,
+    // from int to short (if internal_int_t is short) cast implicitly,
     // and it can be error by compiler option -Werror=conversion.
-    fixed_point_ = static_cast<IntType>(fixed_point_ + rhs.fixed_point_);
+    fixed_point_ = static_cast<internal_int_t>(fixed_point_ + rhs.fixed_point_);
     return *this;
   }
 
@@ -128,9 +128,9 @@ class fixed_t {
     //   fixed_point_ += rhs.fixed_point_;
     // is not valid on some environments.
     // Because implicit integer promotion makes
-    // from int to short (if IntType is short) cast implicitly,
+    // from int to short (if internal_int_t is short) cast implicitly,
     // and it can be error by compiler option -Werror=conversion.
-    fixed_point_ = static_cast<IntType>(fixed_point_ - rhs.fixed_point_);
+    fixed_point_ = static_cast<internal_int_t>(fixed_point_ - rhs.fixed_point_);
     return *this;
   }
 
@@ -235,13 +235,13 @@ class fixed_t {
   std::string ToString() const;
 
   /// Internal integral value holding as fixed point value.
-  IntType fixed_point_;
+  internal_int_t fixed_point_;
 
  private:
   /// Bits width of decimal part of this fixed point number type.
   constexpr static std::size_t kBitsWidthOfDecimalPart = Q;
   /// Coefficient to convert to internal fixed point value.
-  constexpr static IntType kCoef = 1 << Q;
+  constexpr static internal_int_t kCoef = 1 << Q;
 
   /// Convert from some integral type value
   /// to internal integral fixed point type value.
@@ -254,7 +254,7 @@ class fixed_t {
   ///
   /// @return Coverted internal integral fixed point type value.
   template <typename SrcType>
-  constexpr static IntType ToIntType(
+  constexpr static internal_int_t ToInternalType(
       typename std::enable_if<std::is_integral<SrcType>::value,
                               SrcType>::type src);
 
@@ -269,7 +269,7 @@ class fixed_t {
   ///
   /// @return Coverted internal integral fixed point type value.
   template <typename SrcType>
-  constexpr static IntType ToIntType(
+  constexpr static internal_int_t ToInternalType(
       typename std::enable_if<std::is_floating_point<SrcType>::value,
                               SrcType>::type src);
 
@@ -285,7 +285,8 @@ class fixed_t {
   ///
   /// @return Coverted internal integral fixed point type value.
   template <typename SrcIntType, std::size_t SrcQ>
-  constexpr static IntType ToIntType(const fixed_t<SrcIntType, SrcQ>& src);
+  constexpr static
+  internal_int_t ToInternalType(const fixed_t<SrcIntType, SrcQ>& src);
 
   /// Convert to some integral type value
   /// from internal integral fixed point type value.
@@ -300,7 +301,7 @@ class fixed_t {
   template <typename DestType>
   constexpr static
   typename std::enable_if<std::is_integral<DestType>::value, DestType>::type
-  FromIntType(IntType src);
+  FromInternalType(internal_int_t src);
 
   /// Convert to some floating-point type value
   /// from internal integral fixed point type value.
@@ -316,7 +317,7 @@ class fixed_t {
   constexpr static
   typename std::enable_if<std::is_floating_point<DestType>::value,
                           DestType>::type
-  FromIntType(IntType src);
+  FromInternalType(internal_int_t src);
 };
 
 }  // namespace fixedpointnumber

--- a/include/fixedpointnumber_conversion-priv.h
+++ b/include/fixedpointnumber_conversion-priv.h
@@ -29,7 +29,7 @@ namespace fixedpointnumber {
 
 template <typename IntType, std::size_t Q>
 template <typename SrcType>
-constexpr IntType fixed_t<IntType, Q>::ToIntType(
+constexpr IntType fixed_t<IntType, Q>::ToInternalType(
     typename std::enable_if<std::is_integral<SrcType>::value,
                             SrcType>::type src) {
   return static_cast<IntType>(src << kBitsWidthOfDecimalPart);
@@ -37,7 +37,7 @@ constexpr IntType fixed_t<IntType, Q>::ToIntType(
 
 template <typename IntType, std::size_t Q>
 template <typename SrcType>
-constexpr IntType fixed_t<IntType, Q>::ToIntType(
+constexpr IntType fixed_t<IntType, Q>::ToInternalType(
     typename std::enable_if<std::is_floating_point<SrcType>::value,
                             SrcType>::type src) {
   return static_cast<IntType>(src * static_cast<SrcType>(kCoef));
@@ -46,7 +46,7 @@ constexpr IntType fixed_t<IntType, Q>::ToIntType(
 template <typename IntType, std::size_t Q>
 template <typename SrcIntType, std::size_t SrcQ>
 constexpr IntType
-fixed_t<IntType, Q>::ToIntType(const fixed_t<SrcIntType, SrcQ>& src) {
+fixed_t<IntType, Q>::ToInternalType(const fixed_t<SrcIntType, SrcQ>& src) {
   return ((Q > SrcQ)
           ? static_cast<IntType>(src.fixed_point_ << (Q - SrcQ))
           : static_cast<IntType>(src.fixed_point_ >> (SrcQ - Q)));
@@ -56,7 +56,7 @@ template <typename IntType, std::size_t Q>
 template <typename DestType>
 constexpr
 typename std::enable_if<std::is_integral<DestType>::value, DestType>::type
-fixed_t<IntType, Q>::FromIntType(IntType src) {
+fixed_t<IntType, Q>::FromInternalType(IntType src) {
   return static_cast<DestType>(src >> kBitsWidthOfDecimalPart);
 }
 
@@ -64,7 +64,7 @@ template <typename IntType, std::size_t Q>
 template <typename DestType>
 constexpr
 typename std::enable_if<std::is_floating_point<DestType>::value, DestType>::type
-fixed_t<IntType, Q>::FromIntType(IntType src) {
+fixed_t<IntType, Q>::FromInternalType(IntType src) {
   return (static_cast<DestType>(src)
           * (static_cast<DestType>(1.0f) / static_cast<DestType>(kCoef)));
 }

--- a/include/fixedpointnumber_wider_int.h
+++ b/include/fixedpointnumber_wider_int.h
@@ -1,0 +1,95 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+
+#ifndef INCLUDE_FIXEDPOINTNUMBER_WIDER_INT_H_
+#define INCLUDE_FIXEDPOINTNUMBER_WIDER_INT_H_
+
+#ifndef FIXEDPOINTNUMBER_INTERNAL
+#error Do not include this file directly, include fixedpointnumber.h instead.
+#endif
+
+namespace fixedpointnumber {
+
+namespace impl {
+
+/// Helper class to get wider type than specified int type.
+///
+/// @tparam int_t Type to get wider type
+template <typename int_t>
+class WiderIntType {
+};
+
+/// Specialized template helper class to get wider type than int8_t.
+template<>
+class WiderIntType<int8_t> {
+ public:
+  /// Wider type than int8_t.
+  using type = int16_t;
+};
+
+/// Specialized template helper class to get wider type than int16_t.
+template<>
+class WiderIntType<int16_t> {
+ public:
+  /// Wider type than int16_t.
+  using type = int32_t;
+};
+
+/// Specialized template helper class to get wider type than int32_t.
+template<>
+class WiderIntType<int32_t> {
+ public:
+  /// Wider type than int32_t.
+  using type = int64_t;
+};
+
+/// Specialized template helper class to get wider type than uint8_t.
+template<>
+class WiderIntType<uint8_t> {
+ public:
+  /// Wider type than uint8_t.
+  using type = uint16_t;
+};
+
+/// Specialized template helper class to get wider type than uint16_t.
+template<>
+class WiderIntType<uint16_t> {
+ public:
+  /// Wider type than uint16_t.
+  using type = uint32_t;
+};
+
+/// Specialized template helper class to get wider type than uint32_t.
+template<>
+class WiderIntType<uint32_t> {
+ public:
+  /// Wider type than uint32_t.
+  using type = uint64_t;
+};
+
+/// Alias tempalte to wider type than template argument int type.
+template <typename int_t>
+using wider_int_t = typename WiderIntType<int_t>::type;
+
+}  // namespace impl
+
+}  // namespace fixedpointnumber
+
+#endif  // INCLUDE_FIXEDPOINTNUMBER_WIDER_INT_H_

--- a/test/test_arithmetic_mul.cc
+++ b/test/test_arithmetic_mul.cc
@@ -1,0 +1,74 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "fixedpointnumber.h"
+
+using lhs_fixed_t    = fixedpointnumber::fixed_t<int16_t, 2>;
+using rhs_fixed_t    = fixedpointnumber::fixed_t<int16_t, 3>;
+using result_fixed_t = fixedpointnumber::fixed_t<int32_t, 5>;
+
+struct MulResult {
+  template <typename lhs_t, typename rhs_t, typename result_t>
+  constexpr MulResult(lhs_t a, rhs_t b, result_t c)
+      : lhs(a), rhs(b), mul_result(c) {
+  }
+
+  lhs_fixed_t lhs;
+  rhs_fixed_t rhs;
+  result_fixed_t mul_result;
+};
+
+class ArithmeticMulTest
+  : public ::testing::TestWithParam<MulResult> {
+};
+
+TEST_P(ArithmeticMulTest, Add) {
+  const auto param = GetParam();
+  EXPECT_EQ(param.mul_result, fixed_mul(param.lhs, param.rhs));
+}
+
+const MulResult kMulResults[] = {
+  // Combination of negative/positive values.
+  { 0.5f,  0.5f,  0.25f},
+  {-0.5f,  0.5f, -0.25f},
+  { 0.5f, -0.5f, -0.25f},
+  {-0.5f, -0.5f,  0.25f},
+
+  // Results are just one.
+  { 0.5f,    2, 1},
+  {    2, 0.5f, 1},
+
+  // Results are just zero.
+  {      0,  0.25f, 0},
+  {  0.25f,      0, 0},
+  {      0, -0.25f, 0},
+  { -0.25f,      0, 0},
+
+  // Both integers multiply.
+  {  10,  100,  1000},
+  { -10,  100, -1000},
+  { -10, -100,  1000},
+};
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         ArithmeticMulTest,
+                         ::testing::ValuesIn(kMulResults));

--- a/test/test_arithmetic_mul_function.cc
+++ b/test/test_arithmetic_mul_function.cc
@@ -37,11 +37,11 @@ struct MulResult {
   result_fixed_t mul_result;
 };
 
-class ArithmeticMulTest
+class ArithmeticMulFunctionTest
   : public ::testing::TestWithParam<MulResult> {
 };
 
-TEST_P(ArithmeticMulTest, Add) {
+TEST_P(ArithmeticMulFunctionTest, Add) {
   const auto param = GetParam();
   EXPECT_EQ(param.mul_result, fixed_mul(param.lhs, param.rhs));
 }
@@ -70,5 +70,5 @@ const MulResult kMulResults[] = {
 };
 
 INSTANTIATE_TEST_SUITE_P(Instance0,
-                         ArithmeticMulTest,
+                         ArithmeticMulFunctionTest,
                          ::testing::ValuesIn(kMulResults));

--- a/test/test_arithmetic_mul_operator.cc
+++ b/test/test_arithmetic_mul_operator.cc
@@ -1,0 +1,76 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "fixedpointnumber.h"
+
+using fixed_t = fixedpointnumber::fixed_t<int16_t, 4>;
+
+namespace {
+
+struct MulResult {
+  template <typename T>
+  constexpr MulResult(T a, T b, T c)
+      : lhs(a), rhs(b), mul_result(c) {
+  }
+
+  fixed_t lhs;
+  fixed_t rhs;
+  fixed_t mul_result;
+};
+
+const MulResult kMulResults[] = {
+  // Combination of negative/positive values.
+  { 0.5f,  0.5f,  0.25f},
+  {-0.5f,  0.5f, -0.25f},
+  { 0.5f, -0.5f, -0.25f},
+  {-0.5f, -0.5f,  0.25f},
+
+  // Results are just one.
+  { 0.5f, 2.0f, 1.0f},
+  { 2.0f, 0.5f, 1.0f},
+
+  // Results are just zero.
+  {  0.00f,  0.25f, 0.00f},
+  {  0.25f,  0.00f, 0.00f},
+  {  0.00f, -0.25f, 0.00f},
+  { -0.25f,  0.00f, 0.00f},
+
+  // Both integers multiply.
+  {  10,  100,  1000},
+  { -10,  100, -1000},
+  { -10, -100,  1000},
+};
+
+}  // namespace
+
+class ArithmeticMulOperatorTest
+  : public ::testing::TestWithParam<MulResult> {
+};
+
+TEST_P(ArithmeticMulOperatorTest, Mul) {
+  const auto param = GetParam();
+  EXPECT_EQ(param.mul_result, param.lhs * param.rhs);
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         ArithmeticMulOperatorTest,
+                         ::testing::ValuesIn(kMulResults));


### PR DESCRIPTION
- Precision keeping multiply
  - Result type is different from both lhs and rhs type
  - Precision of result is not lossy
  - If you need specified type or precision, it is easy to use `static_cast<>`.
- Type keeping multiply
  - It is `operator*`
  - Type of lhs and rhs must be same
  - Result type is same as lhs and rhs type
  - Precision of result can be lossy