### PR TITLE
Resolve some issues around multiply.

### DIFF
--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -171,8 +171,7 @@ class fixed_t {
   ///
   /// @return Reference to this instance multiplied rhs into.
   fixed_t& operator*=(const fixed_t& rhs) {
-    const fixed_t result = fixed_mul(*this, rhs);
-    *this = static_cast<decltype(*this)>(result);
+    *this = *this * rhs;
     return *this;
   }
 

--- a/test/test_arithmetic_mul_operator.cc
+++ b/test/test_arithmetic_mul_operator.cc
@@ -71,6 +71,11 @@ TEST_P(ArithmeticMulOperatorTest, NormalOperator) {
   EXPECT_EQ(param.mul_result, param.lhs * param.rhs);
 }
 
+TEST_P(ArithmeticMulOperatorTest, CommutativeLaw) {
+  const auto param = GetParam();
+  EXPECT_EQ(param.mul_result, param.rhs * param.lhs);
+}
+
 TEST_P(ArithmeticMulOperatorTest, CompoundOperator) {
   const auto param = GetParam();
   auto lhs = param.lhs;

--- a/test/test_arithmetic_mul_operator.cc
+++ b/test/test_arithmetic_mul_operator.cc
@@ -66,9 +66,16 @@ class ArithmeticMulOperatorTest
   : public ::testing::TestWithParam<MulResult> {
 };
 
-TEST_P(ArithmeticMulOperatorTest, Mul) {
+TEST_P(ArithmeticMulOperatorTest, NormalOperator) {
   const auto param = GetParam();
   EXPECT_EQ(param.mul_result, param.lhs * param.rhs);
+}
+
+TEST_P(ArithmeticMulOperatorTest, CompoundOperator) {
+  const auto param = GetParam();
+  auto lhs = param.lhs;
+  lhs *= param.rhs;
+  EXPECT_EQ(param.mul_result, lhs);
 }
 
 INSTANTIATE_TEST_SUITE_P(Instance0,


### PR DESCRIPTION
- #62 Resolved compound multiply `operator*=` has not been worked
- #63 Added a test for multiply commutative law