### PR TITLE
Added a new sample program to calc pi by Monte Carlo.

### DIFF
--- a/sample/main.cc
+++ b/sample/main.cc
@@ -16,10 +16,19 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
 
+#include "fixedpointnumber.h"
+
 #include "pi_by_leibniz.h"
+#include "pi_by_monte_carlo.h"
 
 int main(int, char**) {
   fixedpointnumber::sample::PrintPiByLeibniz();
+
+  fixedpointnumber::sample::PrintPiByMonteCarlo(100.0f, 1.0f);
+
+  using monte_carlo_fixed_t = fixedpointnumber::fixed_t<int32_t, 16>;
+  fixedpointnumber::sample::PrintPiByMonteCarlo<monte_carlo_fixed_t>(
+      monte_carlo_fixed_t(100.0f), monte_carlo_fixed_t(1.0f));
 
   return 0;
 }

--- a/sample/main.cc
+++ b/sample/main.cc
@@ -16,10 +16,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "pi_sample.h"
+#include "pi_by_leibniz.h"
 
 int main(int, char**) {
-  fixedpointnumber::sample::PrintPiSample();
+  fixedpointnumber::sample::PrintPiByLeibniz();
 
   return 0;
 }

--- a/sample/pi_by_leibniz.cc
+++ b/sample/pi_by_leibniz.cc
@@ -16,7 +16,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "pi_sample.h"
+#include "pi_by_leibniz.h"
 
 #include <cstdint>
 #include <ostream>
@@ -34,7 +34,7 @@ constexpr fixed_t kFour(4);
 
 constexpr int kDefaultLoopCount = 1000;
 
-fixed_t CalcPi(int32_t converge_loop_count) {
+fixed_t CalcPiByLeibniz(int32_t converge_loop_count) {
   fixed_t pi(0);
   const fixed_t end(converge_loop_count);
   fixed_t denom = kOne;
@@ -48,7 +48,7 @@ fixed_t CalcPi(int32_t converge_loop_count) {
   return pi;
 }
 
-auto CalcPiHighPrecision(int32_t converge_loop_count)
+auto CalcPiByLeibnizHighPrecision(int32_t converge_loop_count)
     -> decltype(fixedpointnumber::fixed_div(kFour, kOne)) {
   decltype(fixedpointnumber::fixed_div(kFour, kOne)) pi(0);
   const fixed_t end(converge_loop_count);
@@ -69,12 +69,15 @@ namespace fixedpointnumber {
 
 namespace sample {
 
-void PrintPiSample() {
-  const auto pi = CalcPi(kDefaultLoopCount);
-  std::cout << "PI = " << pi << std::endl;
+void PrintPiByLeibniz() {
+  const auto pi = CalcPiByLeibniz(kDefaultLoopCount);
+  std::cout << "PI by Leibniz fomula = " << pi << std::endl;
 
-  const auto pi_high_precision = CalcPiHighPrecision(kDefaultLoopCount);
-  std::cout << "PI(High precision) = " << pi_high_precision << std::endl;
+  const auto pi_high_precision =
+      CalcPiByLeibnizHighPrecision(kDefaultLoopCount);
+  std::cout << "PI by Leibniz fomula (High precision) = "
+            << pi_high_precision
+            << std::endl;
 
   return;
 }

--- a/sample/pi_by_leibniz.h
+++ b/sample/pi_by_leibniz.h
@@ -16,17 +16,17 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef SAMPLE_PI_SAMPLE_H_
-#define SAMPLE_PI_SAMPLE_H_
+#ifndef SAMPLE_PI_BY_LEIBNIZ_H_
+#define SAMPLE_PI_BY_LEIBNIZ_H_
 
 namespace fixedpointnumber {
 
 namespace sample {
 
-void PrintPiSample();
+void PrintPiByLeibniz();
 
 }  // namespace sample
 
 }  // namespace fixedpointnumber
 
-#endif  // SAMPLE_PI_SAMPLE_H_
+#endif  // SAMPLE_PI_BY_LEIBNIZ_H_

--- a/sample/pi_by_monte_carlo.h
+++ b/sample/pi_by_monte_carlo.h
@@ -1,0 +1,62 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef SAMPLE_PI_BY_MONTE_CARLO_H_
+#define SAMPLE_PI_BY_MONTE_CARLO_H_
+
+#include <iostream>
+#include <typeinfo>
+
+namespace fixedpointnumber {
+
+namespace sample {
+
+namespace impl {
+
+template <typename T>
+T CalcPiByMonteCarlo(T radius, T step) {
+  const T num_of_all_grid = (radius / step + T(1)) * (radius / step + T(1));
+  T num_of_grid_in_radius(0);
+  for (T y(0); y <= radius; y += step) {
+    for (T x(0); x <= radius; x += step) {
+      if ((x * x + y * y) < (radius * radius)) {
+        ++num_of_grid_in_radius;
+      }
+    }
+  }
+  return num_of_grid_in_radius * T(4) / num_of_all_grid;
+}
+
+}  // namespace impl
+
+template <typename T>
+void PrintPiByMonteCarlo(T radius, T step) {
+  std::cout << "Pi by Monte Carlo ("
+            << typeid(T).name()
+            << ") = "
+            << impl::CalcPiByMonteCarlo<T>(radius, step)
+            << std::endl;
+
+  return;
+}
+
+}  // namespace sample
+
+}  // namespace fixedpointnumber
+
+#endif  // SAMPLE_PI_BY_MONTE_CARLO_H_


### PR DESCRIPTION
# Summary

- Added a new sample program to calc pi by Monte Carlo

# Details

- Print pi calculated by Monte Carlo method
- It shows lesser precision because it is only using sequential values as grids
  - Typical implementations of Monte Carlo method use random values as grids to increase denominator

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [x] Sample program

# References

- #78 

# Notes

- N/A
