### PR TITLE
Added "sample" into make target "all" to build samples by default.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
   - [ ] Those tests already exists
   - [ ] Those tests are included in this PR
 - [ ] Sample program
+- [ ] CI
 
 # References
 

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ DOXYFILE := $(BUILD_FILES_DIR)/Doxyfile
 DOXYGEN_TARGET_SRCS := $(INCLUDE_DIR_HEADER)
 
 # Targets.
-all: test
+all: test sample
 
 clean:
 	-rm $(TEST_OBJS) $(TEST_DEPS) $(SAMPLE_OBJS) $(SAMPLE_DEPS)


### PR DESCRIPTION
# Summary

- Build samples by default "make"

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# Note

- CI doesn't test "make all" but we can confirm this change doesn't break other targets by CI
