### PR TITLE
Suppress warning by Visual C++ in bit shifting by negative number.

### DIFF
--- a/include/fixedpointnumber_conversion-priv.h
+++ b/include/fixedpointnumber_conversion-priv.h
@@ -123,9 +123,16 @@ template <typename IntType, std::size_t Q>
 template <typename SrcIntType, std::size_t SrcQ>
 constexpr IntType
 fixed_t<IntType, Q>::ToInternalType(const fixed_t<SrcIntType, SrcQ>& src) {
+#ifdef _MSC_VER  // Suppress warning at shifting by negative number.
+#pragma warning(push)
+#pragma warning(disable:4293)
+#endif  // _MSC_VER
   return ((Q > SrcQ)
           ? static_cast<IntType>(src.fixed_point_ << (Q - SrcQ))
           : static_cast<IntType>(src.fixed_point_ >> (SrcQ - Q)));
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 }
 
 template <typename IntType, std::size_t Q>


### PR DESCRIPTION
# Summary

- Suppress warning by Visual C++ in bit shifting by negative number

# Details

- Use `#pragma` to suppress warning

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #94 

# Notes

- N/A
