### PR TITLE
Support environments which do not support floating point types.

### DIFF
--- a/include/fixedpointnumber_conversion-priv.h
+++ b/include/fixedpointnumber_conversion-priv.h
@@ -149,7 +149,7 @@ constexpr
 typename std::enable_if<std::is_floating_point<DestType>::value, DestType>::type
 fixed_t<IntType, Q>::FromInternalType(IntType src) {
   return (static_cast<DestType>(src)
-          * (static_cast<DestType>(1.0f) / static_cast<DestType>(kCoef)));
+          * (static_cast<DestType>(1) / static_cast<DestType>(kCoef)));
 }
 
 }  // namespace fixedpointnumber

--- a/include/fixedpointnumber_math_round-priv.h
+++ b/include/fixedpointnumber_math_round-priv.h
@@ -42,8 +42,15 @@ constexpr fixed_t<IntType, Q> fixed_ceil_positive(fixed_t<IntType, Q> src) {
 }
 
 template <typename IntType, std::size_t Q>
+constexpr fixed_t<IntType, Q> GetZeroPointFive() {
+  // From string ctor like as fixed_t<IntType, Q>("0.5") can't be suitable here,
+  // because that ctor is not constexpr ctor now.
+  return fixed_t<IntType, Q>(static_cast<IntType>(1 << (Q - 1)), true);
+}
+
+template <typename IntType, std::size_t Q>
 constexpr fixed_t<IntType, Q> fixed_round_positive(fixed_t<IntType, Q> src) {
-  return fixed_floor_positive(src + fixed_t<IntType, Q>(0.5f));
+  return fixed_floor_positive(src + GetZeroPointFive<IntType, Q>());
 }
 
 template <typename IntType, std::size_t Q>
@@ -58,7 +65,7 @@ constexpr fixed_t<IntType, Q> fixed_ceil_negative(fixed_t<IntType, Q> src) {
 
 template <typename IntType, std::size_t Q>
 constexpr fixed_t<IntType, Q> fixed_round_negative(fixed_t<IntType, Q> src) {
-  return fixed_ceil_negative(src - fixed_t<IntType, Q>(0.5f));
+  return fixed_ceil_negative(src - GetZeroPointFive<IntType, Q>());
 }
 
 }  // namespace impl


### PR DESCRIPTION
# Summary

- Support environments which do not support floating point types.

# Details

- Eliminated floating point constants like as 0.5f.

# Continuous operation guarantee by

- [x] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #107 

# Notes

- N/A
