### PR TITLE
Supported fixed_trunc() function.

### DIFF
--- a/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
+++ b/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
@@ -70,6 +70,7 @@
     <ClCompile Include="..\..\..\..\test\test_math_mod.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_round.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_signbit.cc" />
+    <ClCompile Include="..\..\..\..\test\test_math_trunc.cc" />
     <ClCompile Include="..\..\..\..\test\test_int32_int16fixed_conversion.cc" />
     <ClCompile Include="..\..\..\..\test\test_move_constructor_operator.cc" />
     <ClCompile Include="..\..\..\..\test\test_numeric_limits_bool_consts.cc" />

--- a/include/fixedpointnumber_math_round-priv.h
+++ b/include/fixedpointnumber_math_round-priv.h
@@ -186,6 +186,27 @@ constexpr auto fixed_round(fixed_t<IntType, Q> src)
   return impl::fixed_round_positive(src);
 }
 
+/// Compute the truncated integral value.
+///
+/// Result value is
+///
+/// - Truncated toward zero
+/// - Integral (decimal part is zero)
+///
+/// So this function works fixed_floor() for positive value
+/// and fixed_ceil() for negative value.
+///
+/// @tparam IntType Internal int type for type fixed_t template param
+/// @tparam Q       Q for type fixed_t template param
+///
+/// @param src value to compute truncated integral value
+///
+/// @return The truncated integral value
+template <typename IntType, std::size_t Q>
+constexpr fixed_t<IntType, Q> fixed_trunc(fixed_t<IntType, Q> src) {
+  return (src >= fixed_t<IntType, Q>(0)) ? fixed_floor(src) : fixed_ceil(src);
+}
+
 }  // namespace fixedpointnumber
 
 #endif  // INCLUDE_FIXEDPOINTNUMBER_MATH_ROUND_PRIV_H_

--- a/test/test_math_trunc.cc
+++ b/test/test_math_trunc.cc
@@ -1,0 +1,53 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cmath>
+#include <cstdint>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+namespace {
+
+using fixed_t = fixedpointnumber::fixed_t<int16_t, 7>;
+
+}  // namespace
+
+class TruncTest
+  : public ::testing::TestWithParam<fixed_t> {
+};
+
+TEST_P(TruncTest, Validate) {
+  const auto trunc_result = fixedpointnumber::fixed_trunc(GetParam());
+  EXPECT_TRUE((fixedpointnumber::fixed_signbit(GetParam())
+               == fixedpointnumber::fixed_signbit(trunc_result))
+              || (trunc_result == fixed_t(0)));
+  EXPECT_LE(fixedpointnumber::fixed_abs(trunc_result),
+            fixedpointnumber::fixed_abs(GetParam()));
+  EXPECT_LT(fixedpointnumber::fixed_abs(GetParam() - trunc_result),
+            fixed_t(1));
+  EXPECT_EQ(trunc_result, fixedpointnumber::fixed_trunc(trunc_result));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         TruncTest,
+                         ::testing::Range(fixed_t("-2.0"),
+                                          fixed_t("2.125"),
+                                          fixed_t("0.25")));


### PR DESCRIPTION
# Summary

- Supported `fixed_trunc()` function

# Details

- Supported function to compute truncated value like as `std::trunc()` in `cmath`
  - It works as fixed_floor() for positive value
  - It works as fixed_ceil() for negative value

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #110 

# Notes

- N/A
