### PR TITLE
Resolved error on deploying static pages by missing gtest.

### DIFF
--- a/.github/workflows/deploy_github_pages.yml
+++ b/.github/workflows/deploy_github_pages.yml
@@ -22,6 +22,13 @@ jobs:
         sudo apt update
         sudo apt install -y --no-install-recommends graphviz doxygen
 
+    - name: Install googletest
+      run: |
+        git clone https://github.com/google/googletest.git
+        cd googletest
+        cmake -DBUILD_GMOCK=OFF -DCMAKE_CXX_STANDARD=11 .
+        sudo make -k -j all install
+
     - name: Build site
       run: |
         make BUILD_TYPE=coverage -k -j site


### PR DESCRIPTION
# Summary

- 

# Details

- 

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #125 

# Notes

- 
