### PR TITLE
Added Doxygen comments for fixedpointnumber::numeric_limits<T> .

### DIFF
--- a/build/Doxyfile
+++ b/build/Doxyfile
@@ -1510,7 +1510,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # The ENUM_VALUES_PER_LINE tag can be used to set the number of enum values that
 # doxygen will group on one line in the generated HTML documentation.

--- a/include/constexpr_string.h
+++ b/include/constexpr_string.h
@@ -19,8 +19,6 @@
 #ifndef INCLUDE_CONSTEXPR_STRING_H_
 #define INCLUDE_CONSTEXPR_STRING_H_
 
-#include <cstddef>
-
 namespace constexprstr {
 
 /// constexpr version of std::strlen().

--- a/include/fixedpointnumber_limits.h
+++ b/include/fixedpointnumber_limits.h
@@ -23,6 +23,9 @@
 
 namespace fixedpointnumber {
 
+/// std::numeric_limits compatible functions for fixed_t.
+///
+/// @tparam T Instantiated class of fixed_t template class to know limits
 template <class T>
 class numeric_limits {
  public:

--- a/include/fixedpointnumber_limits.h
+++ b/include/fixedpointnumber_limits.h
@@ -175,11 +175,11 @@ template <class T> constexpr const bool numeric_limits<T>::is_exact;
 template <class T> constexpr const bool numeric_limits<T>::has_infinity;
 template <class T> constexpr const bool numeric_limits<T>::has_quiet_NaN;
 template <class T> constexpr const bool numeric_limits<T>::has_signaling_NaN;
-template <class T> constexpr const
-std::float_denorm_style numeric_limits<T>::has_denorm;
+template <class T>
+constexpr const std::float_denorm_style numeric_limits<T>::has_denorm;
 template <class T> constexpr const bool numeric_limits<T>::has_denorm_loss;
-template <class T> constexpr const
-std::float_round_style numeric_limits<T>::round_style;
+template <class T>
+constexpr const std::float_round_style numeric_limits<T>::round_style;
 template <class T> constexpr const bool numeric_limits<T>::is_iec559;
 template <class T> constexpr const bool numeric_limits<T>::is_bounded;
 template <class T> constexpr const bool numeric_limits<T>::is_modulo;

--- a/include/fixedpointnumber_limits.h
+++ b/include/fixedpointnumber_limits.h
@@ -19,7 +19,6 @@
 #ifndef INCLUDE_FIXEDPOINTNUMBER_LIMITS_H_
 #define INCLUDE_FIXEDPOINTNUMBER_LIMITS_H_
 
-#include <cstddef>
 #include <limits>
 
 namespace fixedpointnumber {


### PR DESCRIPTION
# Summary

- Added Doxygen comments for `fixedpointnumber::numeric_limits<T>`

# Details

- Added Doxygen comments for `fixedpointnumber::numeric_limits<T>`
- Some refactorings
  - Removed some unnecessary includes
  - Modified line break position for readability
- Enable treeview of Doxygen output HTML

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #128 

# Notes

- N/A
