### PR TITLE
Brush up constexprmath and constexprstr.

### DIFF
--- a/include/constexpr_math.h
+++ b/include/constexpr_math.h
@@ -41,9 +41,8 @@ namespace constexprmath {
 /// @note In current implementation limits,
 ///       returns 1 as results for negative n parameter.
 template <typename T>
-constexpr T cpowi(
-    typename std::enable_if<std::is_integral<T>::value, T>::type x,
-    T n) {
+constexpr auto cpowi(T x, T n)
+    -> typename std::enable_if<std::is_integral<T>::value, T>::type {
   return ((n > 0)
           ? (((n % 2) == 0)
              ? (cpowi(x, n / 2) * cpowi(x, n / 2))

--- a/include/constexpr_math.h
+++ b/include/constexpr_math.h
@@ -24,6 +24,9 @@
 namespace constexprmath {
 
 /// @addtogroup constexprmath constexprmath
+///
+/// constexprmath provides some math functions as constexpr functions.
+///
 /// @{
 
 /// Calculate x^n.

--- a/include/constexpr_string.h
+++ b/include/constexpr_string.h
@@ -22,6 +22,9 @@
 namespace constexprstr {
 
 /// @addtogroup constexprstr constexprstr
+///
+/// constexprstr provides some string functions as constexpr functions.
+///
 /// @{
 
 /// constexpr version of std::strlen().

--- a/include/fixedpointnumber_conversion-priv.h
+++ b/include/fixedpointnumber_conversion-priv.h
@@ -80,12 +80,14 @@ constexpr IntType FromStringToDecimalInt(const char* str) {
 
 template <typename IntType>
 constexpr IntType FromStringDecimalCoef(const char* str) {
+  using cstrlen_return_t = decltype(constexprstr::cstrlen(""));
+
   return static_cast<IntType>(constexprstr::cstrchr(str, '.')
                               ? constexprmath::cpowi(
-                                  10,
+                                  cstrlen_return_t(10),
                                   constexprstr::cstrlen(
                                       constexprstr::cstrchr(str, '.') + 1))
-                              : 1);
+                              : cstrlen_return_t(1));
 }
 
 }  // namespace impl


### PR DESCRIPTION
# Summary

- Brush up `constexprmath` and `constexprstr`

# Details

- Refined definition of `constexprmath::cpowi()` for readability
- Added documents for Doxygen groups of `constexprmath` and `constexprstr`

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- N/A

# Notes

- N/A
