### PR TITLE
Supported power of negative in cpowi()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ WARNING_CXXFLAGS += -Wzero-as-null-pointer-constant
 WARNING_CXXFLAGS += -Wall
 WARNING_CXXFLAGS += -Wextra
 WARNING_CXXFLAGS += -Werror
+WARNING_CXXFLAGS += -Wno-error=inline
 # Following warning options are valid for C/Obj-C but not for C++ on gcc.
 # WARNING_CXXFLAGS += -Wc++-compat
 # WARNING_CXXFLAGS += -Wmissing-prototypes

--- a/include/constexpr_math.h
+++ b/include/constexpr_math.h
@@ -48,7 +48,9 @@ constexpr T cpowi(
           ? (((n % 2) == 0)
              ? (cpowi(x, n / 2) * cpowi(x, n / 2))
              : (cpowi(x, n / 2) * cpowi(x, n / 2) * x))
-          : 1);
+          : ((n < 0)
+             ? (1 / cpowi(x, -n))
+             : 1));
 }
 
 /// @}

--- a/test/test_constexpr_math.cc
+++ b/test/test_constexpr_math.cc
@@ -34,5 +34,36 @@ TEST(ConstexprMathTest, cpowi_constexpr) {
 
 TEST(ConstexprMathTest, cpowi_negative_nth_power_limitation) {
   constexpr auto cpowi_result = constexprmath::cpowi(5, -8);
-  EXPECT_EQ(1, cpowi_result);
+  EXPECT_EQ(0, cpowi_result);
 }
+
+class CpowiOneToThePowerOfNegativeTest
+    : public ::testing::TestWithParam<int32_t> {
+};
+
+TEST_P(CpowiOneToThePowerOfNegativeTest, MustBeOne) {
+  EXPECT_EQ(1, constexprmath::cpowi(1, GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         CpowiOneToThePowerOfNegativeTest,
+                         ::testing::Range(-3, -1));
+
+class CpowiMoreThanOneToThePowerOfNegativeTest
+    : public ::testing::TestWithParam<std::tuple<int32_t, int32_t>> {
+};
+
+TEST_P(CpowiMoreThanOneToThePowerOfNegativeTest, MustBeZero) {
+  EXPECT_EQ(0, constexprmath::cpowi(std::get<0>(GetParam()),
+                                    std::get<1>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Positive,
+                         CpowiMoreThanOneToThePowerOfNegativeTest,
+                         ::testing::Combine(::testing::Range(2, 3),
+                                            ::testing::Range(-3, -1)));
+
+INSTANTIATE_TEST_SUITE_P(Negative,
+                         CpowiMoreThanOneToThePowerOfNegativeTest,
+                         ::testing::Combine(::testing::Range(-3, -1),
+                                            ::testing::Range(-3, -1)));

--- a/test/test_constexpr_math.cc
+++ b/test/test_constexpr_math.cc
@@ -33,6 +33,6 @@ TEST(ConstexprMathTest, cpowi_constexpr) {
 }
 
 TEST(ConstexprMathTest, cpowi_negative_nth_power_limitation) {
-  constexpr auto cpowi_result = constexprmath::cpowi(5, -20);
+  constexpr auto cpowi_result = constexprmath::cpowi(5, -8);
   EXPECT_EQ(1, cpowi_result);
 }


### PR DESCRIPTION
# Summary

- Supported power of negative in `cpowi()`

# Details

- Supported power of negative in `cpowi()`
  - And resolved overflow in test which is caused by it

# Continuous operation guarantee by

- [x] Unit tests
  - [x] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #132

# Notes

- N/A
