### PR TITLE
Supported fixed_remainder() and fixed_remquo().

### DIFF
--- a/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
+++ b/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile Include="..\..\..\..\test\test_math_isunordered.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_mod.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_modf.cc" />
+    <ClCompile Include="..\..\..\..\test\test_math_remainder.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_round.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_signbit.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_trunc.cc" />

--- a/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
+++ b/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
@@ -79,6 +79,7 @@
     <ClCompile Include="..\..\..\..\test\test_math_mod.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_modf.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_remainder.cc" />
+    <ClCompile Include="..\..\..\..\test\test_math_remquo.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_round.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_signbit.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_trunc.cc" />

--- a/include/fixedpointnumber_math.h
+++ b/include/fixedpointnumber_math.h
@@ -29,6 +29,7 @@
 #include "fixedpointnumber_math_mod-priv.h"
 #include "fixedpointnumber_math_modf-priv.h"
 #include "fixedpointnumber_math_remainder-priv.h"
+#include "fixedpointnumber_math_remquo-priv.h"
 #include "fixedpointnumber_math_round-priv.h"
 #include "fixedpointnumber_math_signbit-priv.h"
 

--- a/include/fixedpointnumber_math.h
+++ b/include/fixedpointnumber_math.h
@@ -28,6 +28,7 @@
 #include "fixedpointnumber_math_fma-priv.h"
 #include "fixedpointnumber_math_mod-priv.h"
 #include "fixedpointnumber_math_modf-priv.h"
+#include "fixedpointnumber_math_remainder-priv.h"
 #include "fixedpointnumber_math_round-priv.h"
 #include "fixedpointnumber_math_signbit-priv.h"
 

--- a/include/fixedpointnumber_math_remainder-priv.h
+++ b/include/fixedpointnumber_math_remainder-priv.h
@@ -1,0 +1,50 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef INCLUDE_FIXEDPOINTNUMBER_MATH_REMAINDER_PRIV_H_
+#define INCLUDE_FIXEDPOINTNUMBER_MATH_REMAINDER_PRIV_H_
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+#ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
+#error Do not include this file directly, ixedpointnumber_math.h instead.
+#endif
+
+namespace fixedpointnumber {
+
+/// Compute the quotient remainder.
+///
+/// @tparam IntType Internal int type for type fixed_t template param
+/// @tparam Q       Q for type fixed_t template param
+///
+/// @param num   Numerator
+/// @param denom Denominator
+///
+/// @return The quotient remainder of num / denom
+///
+/// @relates fixed_t
+template <typename IntType, std::size_t Q>
+constexpr fixed_t<IntType, Q> fixed_remainder(fixed_t<IntType, Q> num,
+                                              fixed_t<IntType, Q> denom) {
+  return (num - fixed_round(num / denom) * denom);
+}
+
+}  // namespace fixedpointnumber
+
+#endif  // INCLUDE_FIXEDPOINTNUMBER_MATH_REMAINDER_PRIV_H_

--- a/include/fixedpointnumber_math_remquo-priv.h
+++ b/include/fixedpointnumber_math_remquo-priv.h
@@ -1,0 +1,52 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef INCLUDE_FIXEDPOINTNUMBER_MATH_REMQUO_PRIV_H_
+#define INCLUDE_FIXEDPOINTNUMBER_MATH_REMQUO_PRIV_H_
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+#ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
+#error Do not include this file directly, ixedpointnumber_math.h instead.
+#endif
+
+namespace fixedpointnumber {
+
+/// Compute remainder and quotient.
+///
+/// @tparam IntType Internal int type for type fixed_t template param
+/// @tparam Q       Q for type fixed_t template param
+///
+/// @param[in]  num   Numerator
+/// @param[in]  denom Denominator
+/// @param[out] quo   Quotient
+///
+/// @return The quotient remainder of num / denom
+///
+/// @relates fixed_t
+template <typename IntType, std::size_t Q>
+constexpr fixed_t<IntType, Q> fixed_remquo(fixed_t<IntType, Q> num,
+                                           fixed_t<IntType, Q> denom,
+                                           fixed_t<IntType, Q>* quo) {
+  return *quo = fixed_round(num / denom), fixed_remainder(num, denom);
+}
+
+}  // namespace fixedpointnumber
+
+#endif  // INCLUDE_FIXEDPOINTNUMBER_MATH_REMQUO_PRIV_H_

--- a/test/test_math_remainder.cc
+++ b/test/test_math_remainder.cc
@@ -1,0 +1,82 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cmath>
+#include <cstdint>
+#include <tuple>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+namespace {
+
+using fixed_t = fixedpointnumber::fixed_t<int16_t, 7>;
+
+}  // namespace
+
+class RemainderTest
+    : public ::testing::TestWithParam<std::tuple<fixed_t, fixed_t>> {
+ public:
+  RemainderTest()
+      : num_(0), denom_(0), quotient_(0), remainder_(0) {
+  }
+
+ protected:
+  void SetUp() override {
+    num_ = std::get<0>(GetParam());
+    denom_ = std::get<1>(GetParam());
+    remainder_ = fixedpointnumber::fixed_remainder(num_, denom_);
+    quotient_ = (num_ - remainder_) / denom_;
+  }
+
+  fixed_t num_;
+  fixed_t denom_;
+  fixed_t quotient_;
+  fixed_t remainder_;
+};
+
+TEST_P(RemainderTest, RemainderLessThanDenominator) {
+  EXPECT_LT(fixedpointnumber::fixed_abs(remainder_),
+            fixedpointnumber::fixed_abs(denom_));
+}
+
+TEST_P(RemainderTest, ValidateQuotientAndRemainder) {
+  EXPECT_FLOAT_EQ(static_cast<float>(num_),
+                  static_cast<float>(denom_ * quotient_ + remainder_));
+}
+
+// 2 instances to split range of denominator, for solution of zero division.
+INSTANTIATE_TEST_SUITE_P(PositiveDenom,
+                         RemainderTest,
+                         ::testing::Combine(::testing::Range(fixed_t("-2.0"),
+                                                             fixed_t("2.25"),
+                                                             fixed_t("0.25")),
+                                            ::testing::Range(fixed_t("0.25"),
+                                                             fixed_t("2.25"),
+                                                             fixed_t("0.25"))));
+
+INSTANTIATE_TEST_SUITE_P(NegativeDenom,
+                         RemainderTest,
+                         ::testing::Combine(::testing::Range(fixed_t("-2.0"),
+                                                             fixed_t("2.25"),
+                                                             fixed_t("0.25")),
+                                            ::testing::Range(fixed_t("-2.0"),
+                                                             fixed_t(0),
+                                                             fixed_t("0.25"))));

--- a/test/test_math_remquo.cc
+++ b/test/test_math_remquo.cc
@@ -1,0 +1,81 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cmath>
+#include <cstdint>
+#include <tuple>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+namespace {
+
+using fixed_t = fixedpointnumber::fixed_t<int16_t, 7>;
+
+}  // namespace
+
+class RemQuoTest
+    : public ::testing::TestWithParam<std::tuple<fixed_t, fixed_t>> {
+ public:
+  RemQuoTest()
+      : num_(0), denom_(0), quotient_(0), remainder_(0) {
+  }
+
+ protected:
+  void SetUp() override {
+    num_ = std::get<0>(GetParam());
+    denom_ = std::get<1>(GetParam());
+    remainder_ = fixedpointnumber::fixed_remquo(num_, denom_, &quotient_);
+  }
+
+  fixed_t num_;
+  fixed_t denom_;
+  fixed_t quotient_;
+  fixed_t remainder_;
+};
+
+TEST_P(RemQuoTest, RemainderLessThanDenominator) {
+  EXPECT_LT(fixedpointnumber::fixed_abs(remainder_),
+            fixedpointnumber::fixed_abs(denom_));
+}
+
+TEST_P(RemQuoTest, ValidateRemQuo) {
+  EXPECT_FLOAT_EQ(static_cast<float>(num_),
+                  static_cast<float>(denom_ * quotient_ + remainder_));
+}
+
+// 2 instances to split range of denominator, for solution of zero division.
+INSTANTIATE_TEST_SUITE_P(PositiveDenom,
+                         RemQuoTest,
+                         ::testing::Combine(::testing::Range(fixed_t("-2.0"),
+                                                             fixed_t("2.25"),
+                                                             fixed_t("0.25")),
+                                            ::testing::Range(fixed_t("0.25"),
+                                                             fixed_t("2.25"),
+                                                             fixed_t("0.25"))));
+
+INSTANTIATE_TEST_SUITE_P(NegativeDenom,
+                         RemQuoTest,
+                         ::testing::Combine(::testing::Range(fixed_t("-2.0"),
+                                                             fixed_t("2.25"),
+                                                             fixed_t("0.25")),
+                                            ::testing::Range(fixed_t("-2.0"),
+                                                             fixed_t(0),
+                                                             fixed_t("0.25"))));


### PR DESCRIPTION
# Summary

- Supported `fixed_remainder()` and `fixed_remquo()`

# Details

- `std::remainder()` and `std::remquo()` in `cmath` compatible functions for `fixed_t`
  - `fixed_remainder()`
    - Compute the quotient remainer (only returns remainder)
  - `fixed_remquo()`
    - Compute the quotient and the remainder (returns both quotient and remainder)

# Continuous operation guarantee by

- [x] Unit tests
  - [ ] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #145
- #146 

# Notes

- N/A
