### PR TITLE
Hide some internal implementations from output of Doxygen.

### DIFF
--- a/include/fixedpointnumber_wider_int-priv.h
+++ b/include/fixedpointnumber_wider_int-priv.h
@@ -29,6 +29,8 @@ namespace fixedpointnumber {
 
 namespace impl {
 
+/// @cond WiderIntType
+
 /// Helper class to get wider type than specified int type.
 ///
 /// @tparam int_t Type to get wider type
@@ -109,6 +111,8 @@ class WiderIntType<uint64_t> {
 /// Alias tempalte to wider type than template argument int type.
 template <typename int_t>
 using wider_int_t = typename WiderIntType<int_t>::type;
+
+/// @endcond
 
 }  // namespace impl
 


### PR DESCRIPTION
# Summary

- Hide some internal implementations from output of Doxygen

# Details

- Hide some internal implementations for template class `WiderIntType` from output of Doxygen

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- N/A

# Notes

- This will not affect compiled binaries
