### PR TITLE
Resolved warning for `PATH` in GitHub Actions.

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - if: contains(matrix.os, 'windows')
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Install gcovr (Ubuntu)
       if: contains(matrix.os, 'ubuntu') && matrix.build_type == 'coverage'


### PR DESCRIPTION
# Summary

- #155

# Details

- Resolved warning for `PATH` in GitHub Actions

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #155

# Notes

- N/A
