### PR TITLE
Supported fixed_nextafter() and fixed_nexttoward().

### DIFF
--- a/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
+++ b/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
@@ -79,6 +79,7 @@
     <ClCompile Include="..\..\..\..\test\test_math_lerp.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_mod.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_modf.cc" />
+    <ClCompile Include="..\..\..\..\test\test_math_nextafter.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_remainder.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_remquo.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_round.cc" />

--- a/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
+++ b/build/win_vs/libfixedpointnumber/libfixedpointnumber_test/libfixedpointnumber_test.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="..\..\..\..\test\test_math_mod.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_modf.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_nextafter.cc" />
+    <ClCompile Include="..\..\..\..\test\test_math_nexttoward.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_remainder.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_remquo.cc" />
     <ClCompile Include="..\..\..\..\test\test_math_round.cc" />

--- a/include/fixedpointnumber_math.h
+++ b/include/fixedpointnumber_math.h
@@ -29,6 +29,7 @@
 #include "fixedpointnumber_math_lerp-priv.h"
 #include "fixedpointnumber_math_mod-priv.h"
 #include "fixedpointnumber_math_modf-priv.h"
+#include "fixedpointnumber_math_nextafter-priv.h"
 #include "fixedpointnumber_math_remainder-priv.h"
 #include "fixedpointnumber_math_remquo-priv.h"
 #include "fixedpointnumber_math_round-priv.h"

--- a/include/fixedpointnumber_math.h
+++ b/include/fixedpointnumber_math.h
@@ -30,6 +30,7 @@
 #include "fixedpointnumber_math_mod-priv.h"
 #include "fixedpointnumber_math_modf-priv.h"
 #include "fixedpointnumber_math_nextafter-priv.h"
+#include "fixedpointnumber_math_nexttoward-priv.h"
 #include "fixedpointnumber_math_remainder-priv.h"
 #include "fixedpointnumber_math_remquo-priv.h"
 #include "fixedpointnumber_math_round-priv.h"

--- a/include/fixedpointnumber_math_nextafter-priv.h
+++ b/include/fixedpointnumber_math_nextafter-priv.h
@@ -1,0 +1,55 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef INCLUDE_FIXEDPOINTNUMBER_MATH_NEXTAFTER_PRIV_H_
+#define INCLUDE_FIXEDPOINTNUMBER_MATH_NEXTAFTER_PRIV_H_
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_limits.h"
+#include "fixedpointnumber_math_signbit-priv.h"
+
+#ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
+#error Do not include this file directly, ixedpointnumber_math.h instead.
+#endif
+
+namespace fixedpointnumber {
+
+/// Compute next after value.
+///
+/// @tparam IntType Internal int type for type fixed_t template param
+/// @tparam Q       Q for type fixed_t template param
+///
+/// @param x Value computed next after
+/// @param y Specifiies direction
+///
+/// @return Value next after x in direction of y
+///         which has smallest differenct between x and y
+///
+/// @relates fixed_t
+template <typename IntType, std::size_t Q>
+constexpr fixed_t<IntType, Q> fixed_nextafter(fixed_t<IntType, Q> x,
+                                              fixed_t<IntType, Q> y) {
+  using fixed_t = fixed_t<IntType, Q>;
+  return (fixed_signbit(y)
+          ? (x + numeric_limits<fixed_t>::min())
+          : (x - numeric_limits<fixed_t>::min()));
+}
+
+}  // namespace fixedpointnumber
+
+#endif  // INCLUDE_FIXEDPOINTNUMBER_MATH_NEXTAFTER_PRIV_H_

--- a/include/fixedpointnumber_math_nexttoward-priv.h
+++ b/include/fixedpointnumber_math_nexttoward-priv.h
@@ -1,0 +1,56 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef INCLUDE_FIXEDPOINTNUMBER_MATH_NEXTTOWARD_PRIV_H_
+#define INCLUDE_FIXEDPOINTNUMBER_MATH_NEXTTOWARD_PRIV_H_
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_limits.h"
+
+#include <cmath>
+
+#ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
+#error Do not include this file directly, ixedpointnumber_math.h instead.
+#endif
+
+namespace fixedpointnumber {
+
+/// Compute next toward value.
+///
+/// @tparam IntType Internal int type for type fixed_t template param
+/// @tparam Q       Q for type fixed_t template param
+///
+/// @param x Value computed next toward
+/// @param y Specifiies direction
+///
+/// @return Value next toward x in direction of y
+///         which has smallest differenct between x and y
+///
+/// @relates fixed_t
+template <typename IntType, std::size_t Q>
+constexpr fixed_t<IntType, Q> fixed_nexttoward(fixed_t<IntType, Q> x,
+                                               long double y) {
+  using fixed_t = fixed_t<IntType, Q>;
+  return (std::signbit(y)
+          ? (x + numeric_limits<fixed_t>::min())
+          : (x - numeric_limits<fixed_t>::min()));
+}
+
+}  // namespace fixedpointnumber
+
+#endif  // INCLUDE_FIXEDPOINTNUMBER_MATH_NEXTTOWARD_PRIV_H_

--- a/test/test_math_nextafter.cc
+++ b/test/test_math_nextafter.cc
@@ -1,0 +1,70 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cmath>
+#include <cstdint>
+#include <tuple>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+namespace {
+
+using fixed_t = fixedpointnumber::fixed_t<int16_t, 7>;
+
+}  // namespace
+
+class NextAfterPositiveTest
+    : public ::testing::TestWithParam<std::tuple<fixed_t, fixed_t>> {
+};
+
+TEST_P(NextAfterPositiveTest, Validate) {
+  EXPECT_GT(std::get<0>(GetParam()),
+            fixedpointnumber::fixed_nextafter(std::get<0>(GetParam()),
+                                              std::get<1>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         NextAfterPositiveTest,
+                         ::testing::Combine(::testing::Range(fixed_t(-1),
+                                                             fixed_t("1.5"),
+                                                             fixed_t("0.5")),
+                                            ::testing::Range(fixed_t("0.5"),
+                                                             fixed_t("1.5"),
+                                                             fixed_t("0.5"))));
+
+class NextAfterNegativeTest
+    : public ::testing::TestWithParam<std::tuple<fixed_t, fixed_t>> {
+};
+
+TEST_P(NextAfterNegativeTest, Validate) {
+  EXPECT_LT(std::get<0>(GetParam()),
+            fixedpointnumber::fixed_nextafter(std::get<0>(GetParam()),
+                                              std::get<1>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         NextAfterNegativeTest,
+                         ::testing::Combine(::testing::Range(fixed_t(-1),
+                                                             fixed_t("1.5"),
+                                                             fixed_t("0.5")),
+                                            ::testing::Range(fixed_t(-2),
+                                                             fixed_t(0),
+                                                             fixed_t("0.5"))));

--- a/test/test_math_nexttoward.cc
+++ b/test/test_math_nexttoward.cc
@@ -1,0 +1,70 @@
+//
+// Copyright 2020 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cmath>
+#include <cstdint>
+#include <tuple>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_math.h"
+
+namespace {
+
+using fixed_t = fixedpointnumber::fixed_t<int16_t, 7>;
+
+}  // namespace
+
+class NextTowardPositiveTest
+    : public ::testing::TestWithParam<std::tuple<fixed_t, long double>> {
+};
+
+TEST_P(NextTowardPositiveTest, Validate) {
+  EXPECT_GT(std::get<0>(GetParam()),
+            fixedpointnumber::fixed_nexttoward(std::get<0>(GetParam()),
+                                               std::get<1>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         NextTowardPositiveTest,
+                         ::testing::Combine(::testing::Range(fixed_t(-1),
+                                                             fixed_t("1.5"),
+                                                             fixed_t("0.5")),
+                                            ::testing::Range(0.5L,
+                                                             1.5L,
+                                                             0.5L)));
+
+class NextTowardNegativeTest
+    : public ::testing::TestWithParam<std::tuple<fixed_t, long double>> {
+};
+
+TEST_P(NextTowardNegativeTest, Validate) {
+  EXPECT_LT(std::get<0>(GetParam()),
+            fixedpointnumber::fixed_nexttoward(std::get<0>(GetParam()),
+                                               std::get<1>(GetParam())));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         NextTowardNegativeTest,
+                         ::testing::Combine(::testing::Range(fixed_t(-1),
+                                                             fixed_t("1.5"),
+                                                             fixed_t("0.5")),
+                                            ::testing::Range(-2.0L,
+                                                             0.0L,
+                                                             0.5L)));


### PR DESCRIPTION
# Summary

- Supported `fixed_nextafter()` and `fixed_nexttoward()`

# Details

- Supported following 2 functions and added tests for them
  - `fixed_nextafter()`
  - `fixed_nexttoward()`

# Continuous operation guarantee by

- [x] Unit tests
  - [ ] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #160 
- #161 

# Notes

- N/A
