### PR TITLE
Refactoring: Some refinement for check build workflow.

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -28,15 +28,10 @@ jobs:
     - if: contains(matrix.os, 'windows')
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Install gcovr (Ubuntu)
-      if: contains(matrix.os, 'ubuntu') && matrix.build_type == 'coverage'
+    - name: Install gcovr
+      if: matrix.build_type == 'coverage'
       run: |
         sudo pip3 install gcovr
-
-    - name: Install gcovr (macOS)
-      if: contains(matrix.os, 'macOS') && matrix.build_type == 'coverage'
-      run: |
-        brew install gcovr
 
     - name: Install googletest
       if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
@@ -98,9 +93,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
-    - if: contains(matrix.os, 'windows')
-      uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@v2
+
+    - uses: microsoft/setup-msbuild@v1.0.2
+      if: contains(matrix.os, 'windows')
 
     - name: Build sample program (Ubuntu, macOS)
       if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
@@ -126,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install cpplint.py
       run: |
@@ -144,7 +140,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install cppcheck (Ubuntu)
       if: contains(matrix.os, 'ubuntu')
@@ -158,7 +154,7 @@ jobs:
       run: |
         brew install cppcheck
 
-    - name: cppcheck
+    - name: Run cppcheck
       run: |
         make -k -j cppcheck
 
@@ -166,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install graphviz and doxygen
       run: |


### PR DESCRIPTION
# Summary

- Refactoring: Some refinement for check build workflow.

# Details

- Refined name of step
- Use actions/checkout@v2 instead of @v1
- Use pip to install gcovr on macOS instead of brew
  - Currently coverage is disabled for macOS as default
  - This unifies installation step with Ubuntu

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- N/A

# Notes

- N/A
