### PR TITLE
Resolved 2nd time build `build-sample` doesn't work well.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,16 +228,16 @@ run-calc_pi: $(SAMPLE_OUT_ROOT_DIR)/calc_pi/calc_pi
 
 clean-sample: $(SAMPLES_CLEAN)
 
-$(SAMPLE_OUT_ROOT_DIR)/%:
+$(SAMPLE_OUT_ROOT_DIR)/%: .FORCE
 	$(MAKE) OUT_DIR=$(SAMPLE_OUT_ROOT_DIR)/$(notdir $@) -f $(SAMPLE_SRC_ROOT_DIR)/$(notdir $@)/Makefile
 
-%-clean:
+%-clean: .FORCE
 	$(MAKE) OUT_DIR=$(SAMPLE_OUT_ROOT_DIR)/$(notdir $(subst -clean,,$@)) -f $(subst -clean,,$@)/Makefile clean
 
-%.cpplint:
+%.cpplint: .FORCE
 	$(CPPLINT) $(CPPLINT_FLAGS) $*
 
-%.cppcheck:
+%.cppcheck: .FORCE
 	$(CPPCHECK) $(CPPCHECK_FLAGS) $*
 
 $(DOXYGEN_OUT_DIR): $(SITE_OUT_DIR)
@@ -253,4 +253,5 @@ ifeq ($(findstring clean,$(MAKECMDGOALS)),)
 -include $(TEST_DEPS)
 endif
 
+.FORCE:
 .PHONY: all clean build-sample build-test run-test check cpplint cppcheck doc doxygen site

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ all: build-all
 
 build-all: build-test build-sample
 
-run-all: run-test
+run-all: run-test run-sample
 
 clean: clean-sample
 	- rm $(TEST_OBJS) $(TEST_DEPS)


### PR DESCRIPTION
# Summary

- Resolved 2nd time build `build-sample` doesn't work well

# Details

- Add the build target `run-sample` into `run-all`
- Resolved 2nd time build `build-sample` doesn't work well.

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #176 

# Notes

- N/A
