### PR TITLE
Use C++ compiler pre-defined by make instead of explicit fixed g++.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 export
 
-COMPILER := g++
-
 # Parameters which can be specified make command line.
 BUILD_TYPE := debug
 
@@ -210,11 +208,11 @@ site: $(SITE_OUT_INDEX_HTML) doxygen coverage
 
 $(TEST_EXEC): $(TEST_OBJS)
 	@mkdir -p $(dir $@)
-	$(COMPILER) -o $(TEST_EXEC) $^ $(LDFLAGS) $(TEST_LDFLAGS) $(MY_CXXFLAGS)
+	$(CXX) -o $(TEST_EXEC) $^ $(LDFLAGS) $(TEST_LDFLAGS) $(MY_CXXFLAGS)
 
 $(TEST_OBJ_DIR)%.o: $(TEST_SRC_DIR)/%.cc
 	@mkdir -p $(dir $@)
-	$(COMPILER) $(MY_CXXFLAGS) -o $@ -c $< -MMD -MP
+	$(CXX) $(MY_CXXFLAGS) -o $@ -c $< -MMD -MP
 
 build-sample: $(SAMPLE_EXECS)
 

--- a/build/sample_Makefile
+++ b/build/sample_Makefile
@@ -13,11 +13,11 @@ clean:
 
 $(EXEC): $(OBJS)
 	@mkdir -p $(dir $@)
-	$(COMPILER) -o $@ $^ $(LDFLAGS) $(MY_LDFLAGS) $(MY_CXXFLAGS)
+	$(CXX) -o $@ $^ $(LDFLAGS) $(MY_LDFLAGS) $(MY_CXXFLAGS)
 
 $(OUT_DIR)%.o: $(SRC_DIR)/%.cc
 	@mkdir -p $(dir $@)
-	$(COMPILER) $(MY_CXXFLAGS) -o $@ -c $< -MMD -MP
+	$(CXX) $(MY_CXXFLAGS) -o $@ -c $< -MMD -MP
 
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
 -include $(DEPS)


### PR DESCRIPTION
# Summary

- Use C++ compiler pre-defined by make instead of explicit fixed `g++`

# Details

- Use make defined C++ compiler

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- N/A

# Notes

- N/A
