### PR TITLE
Set variable `CXX` automatically for some compilers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,16 @@ INCLUDE_DIR += include
 INCLUDE_DIR_HEADER :=
 INCLUDE_DIR_HEADER += $(wildcard $(INCLUDE_DIR)/*.h)
 
+# Set C++ compiler for variable CXX
+dummy := $(shell type $(CXX))  # In GNU Make, default CXX should be g++
+ifeq ($(.SHELLSTATUS),0)
+  CXX := clang++
+  dummy := $(shell type $(CXX))
+  ifeq ($(.SHELLSTATUS),0)
+    CXX := c++
+  endif
+endif
+
 SYSTEM_INCLUDE_DIRS :=
 SYSTEM_INCLUDE_DIRS += /usr/local/include
 


### PR DESCRIPTION
# Summary

- Set variable `CXX` automatically for some compilers

# Details

- Searching `g++`, `clang++`, and `c++` automatically in Makefile

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #188 

# Notes

- N/A
