### PR TITLE
Update things around Makefile

### DIFF
--- a/.mdl.style.rb
+++ b/.mdl.style.rb
@@ -1,0 +1,2 @@
+all
+rule 'MD013', :tables => false

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "#{File.dirname(__FILE__)}/.mdl.style.rb"

--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,6 @@ cppcheck: $(CPPCHECK_TARGETS)
 
 doc: $(DOXYGEN_INDEX_HTML)
 
-doxygen: doc
-
 site: $(SITE_OUT_INDEX_HTML) doxygen coverage
 
 $(TEST_EXEC): $(TEST_OBJS)

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,8 @@ Makefile of libfixedpointnumber will provide followings on your environments
 
 | `make` target | How it works |
 ----|----
-| `build-interactive-sample` | Build interactive sample programs |
+| `all` | Same as `build-all` |
+| `build-all` | `build-all` and `build-sample` |
 | `build-sample` | Build sample programs |
 | `build-test` | Build unit tests |
 | `check` | Process `cppcheck` and `cpplint` |
@@ -110,9 +111,10 @@ Makefile of libfixedpointnumber will provide followings on your environments
 | `cppcheck` | Static analytics by `cppcheck` |
 | `cpplint` | Lint by `cpplint` |
 | `doc` | Generate doxygen documents into out/doc |
-| `run-all` | `run-sample` and `run-test` (except interactive-sample)|
+| `run-all` | `run-sample` and `run-test` |
 | `run-sample` | Build (if necessary) and run sample programs |
 | `run-test` | Build (if necessary) and run unit tests |
+| `site` | Build tree for [project site](https://minorusekine.github.io/libfixedpointnumber/) |
 
 ### Build options
 


### PR DESCRIPTION
# Summary

- Update things around Makefile

# Details

- Removed undocumented and redundant make target `doxygen`
- Updated notice for make targets in README.md

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- N/A

# Notes

- N/A
