### PR TITLE
Resolved an invalid notice for build target `build-all` in README.md.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,7 +102,7 @@ Makefile of libfixedpointnumber will provide followings on your environments
 | `make` target | How it works |
 ----|----
 | `all` | Same as `build-all` |
-| `build-all` | `build-all` and `build-sample` |
+| `build-all` | `build-sample` and `build-test` |
 | `build-sample` | Build sample programs |
 | `build-test` | Build unit tests |
 | `check` | Process `cppcheck` and `cpplint` |


### PR DESCRIPTION
# Summary

- Resolved an invalid notice for build target `build-all` in README.md

# Details

- Resolved an invalid notice for build target `build-all` in README.md

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- N/A

# Notes

- N/A
