### PR TITLE
Supported LaTeX and PDF outputs of Doxygen documents.

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -78,6 +78,11 @@ jobs:
         name: coverage_html
         path: out/site/coverage_report
 
+    - name: Test `make clean` works fine (Ubuntu, macOS)
+      if: contains(matrix.os, 'macOS') || contains(matrix.os, 'ubuntu')
+      run: |
+        make BUILD_TYPE=${{ matrix.build_type }} -k -j clean
+
   sample:
     strategy:
       matrix:

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -168,20 +168,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install graphviz and doxygen
+    - name: Install graphviz, doxygen, and TeX
       run: |
         sudo apt update
-        sudo apt install -y --no-install-recommends graphviz doxygen
+        sudo apt install -y --no-install-recommends graphviz doxygen texlive texlive-latex-extra
 
     - name: Make Doxygen documents
       run: |
-        make -k -j doxygen
+        make -k -j doxygen latex pdf
 
     - name: Upload Doxygen documents
       uses: actions/upload-artifact@v1
       with:
         name: doc
-        path: out/site/Doxygen/html
+        path: out/site/Doxygen
 
   markdown-lint:
     name: Lint markdown files.

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ DOXYGEN_INDEX_HTML := $(DOXYGEN_OUT_DIR)/html/index.html
 DOXYFILE := $(BUILD_FILES_DIR)/Doxyfile
 DOXYFILE_FOR_LATEX := $(OUT_ROOT_DIR)/Doxyfile_LaTeX
 DOXYGEN_LATEX := $(DOXYGEN_OUT_DIR)/latex/refman.tex
+DOXYGEN_PDF := $(addsuffix .pdf, $(basename $(DOXYGEN_LATEX)))
 DOXYGEN_TARGET_SRCS := $(INCLUDE_DIR_HEADER)
 
 # Targets.
@@ -277,6 +278,11 @@ $(DOXYGEN_LATEX): $(DOXYGEN_TARGET_SRCS) $(DOXYFILE_FOR_LATEX) $(DOXYGEN_OUT_DIR
 $(DOXYFILE_FOR_LATEX): $(DOXYFILE)
 	@mkdir -p $(dir $(DOXYFILE_FOR_LATEX))
 	sed -e "s/^\([^#]*GENERATE_LATEX *= *\)NO/\1YES/g" $(DOXYFILE) > $@
+
+pdf: $(DOXYGEN_PDF)
+
+$(DOXYGEN_PDF): $(DOXYGEN_LATEX)
+	$(MAKE) -C $(dir $^) pdf
 
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
 -include $(TEST_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ DOXYGEN := doxygen
 DOXYGEN_OUT_DIR := $(SITE_OUT_DIR)/Doxygen
 DOXYGEN_INDEX_HTML := $(DOXYGEN_OUT_DIR)/html/index.html
 DOXYFILE := $(BUILD_FILES_DIR)/Doxyfile
+DOXYFILE_FOR_LATEX := $(OUT_ROOT_DIR)/Doxyfile_LaTeX
+DOXYGEN_LATEX := $(DOXYGEN_OUT_DIR)/latex/refman.tex
 DOXYGEN_TARGET_SRCS := $(INCLUDE_DIR_HEADER)
 
 # Targets.
@@ -267,9 +269,18 @@ $(DOXYGEN_INDEX_HTML): $(DOXYGEN_TARGET_SRCS) $(DOXYFILE) $(DOXYGEN_OUT_DIR)
 $(SITE_OUT_INDEX_HTML): $(SITE_OUT_DIR) $(SITE_SRC_INDEX_HTML)
 	cp -f $(SITE_SRC_INDEX_HTML) $@
 
+latex: $(DOXYGEN_LATEX)
+
+$(DOXYGEN_LATEX): $(DOXYGEN_TARGET_SRCS) $(DOXYFILE_FOR_LATEX) $(DOXYGEN_OUT_DIR)
+	$(DOXYGEN) $(DOXYFILE_FOR_LATEX)
+
+$(DOXYFILE_FOR_LATEX): $(DOXYFILE)
+	@mkdir -p $(dir $(DOXYFILE_FOR_LATEX))
+	sed -e "s/^\([^#]*GENERATE_LATEX *= *\)NO/\1YES/g" $(DOXYFILE) > $@
+
 ifeq ($(findstring clean,$(MAKECMDGOALS)),)
 -include $(TEST_DEPS)
 endif
 
 .FORCE:
-.PHONY: all clean build-sample build-test run-test check cpplint cppcheck doc doxygen site
+.PHONY: all clean build-sample build-test run-test check cpplint cppcheck doc doxygen site latex

--- a/build/Doxyfile
+++ b/build/Doxyfile
@@ -2260,7 +2260,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: NO.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,7 @@ Makefile of libfixedpointnumber will provide followings on your environments
 | `cpplint` | Lint by `cpplint` |
 | `doc` | `coverage` and `doxygen` |
 | `doxygen` | Generate doxygen HTML documents into out/site/Doxygen |
+| `latex` | Generate doxygen LaTeX documents into out/site/Doxygen |
 | `run-all` | `run-sample` and `run-test` |
 | `run-sample` | Build (if necessary) and run sample programs |
 | `run-test` | Build (if necessary) and run unit tests |

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,6 +113,7 @@ Makefile of libfixedpointnumber will provide followings on your environments
 | `doc` | `coverage` and `doxygen` |
 | `doxygen` | Generate doxygen HTML documents into out/site/Doxygen |
 | `latex` | Generate doxygen LaTeX documents into out/site/Doxygen |
+| `pdf` | Generate doxygen PDF documents into out/site/Doxygen |
 | `run-all` | `run-sample` and `run-test` |
 | `run-sample` | Build (if necessary) and run sample programs |
 | `run-test` | Build (if necessary) and run unit tests |


### PR DESCRIPTION
# Summary

- Supported LaTeX and PDF outputs of Doxygen documents

# Details

- Supported LaTeX and PDF outputs of Doxygen documents
- Added test `make clean` works fine in check build

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #192 

# Notes

- N/A
