### PR TITLE
Resolved typo in error message for internal header include guard.

### DIFF
--- a/include/fixedpointnumber_math_abs-priv.h
+++ b/include/fixedpointnumber_math_abs-priv.h
@@ -22,7 +22,7 @@
 #include "fixedpointnumber.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_classification-priv.h
+++ b/include/fixedpointnumber_math_classification-priv.h
@@ -24,7 +24,7 @@
 #include "fixedpointnumber_unused-priv.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_comparison-priv.h
+++ b/include/fixedpointnumber_math_comparison-priv.h
@@ -22,7 +22,7 @@
 #include "fixedpointnumber.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_copysign-priv.h
+++ b/include/fixedpointnumber_math_copysign-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math_signbit-priv.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_fdim-priv.h
+++ b/include/fixedpointnumber_math_fdim-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math_signbit-priv.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_fma-priv.h
+++ b/include/fixedpointnumber_math_fma-priv.h
@@ -22,7 +22,7 @@
 #include "fixedpointnumber.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_lerp-priv.h
+++ b/include/fixedpointnumber_math_lerp-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_mod-priv.h
+++ b/include/fixedpointnumber_math_mod-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_modf-priv.h
+++ b/include/fixedpointnumber_math_modf-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_nextafter-priv.h
+++ b/include/fixedpointnumber_math_nextafter-priv.h
@@ -24,7 +24,7 @@
 #include "fixedpointnumber_math_signbit-priv.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_nexttoward-priv.h
+++ b/include/fixedpointnumber_math_nexttoward-priv.h
@@ -25,7 +25,7 @@
 #include <cmath>
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_remainder-priv.h
+++ b/include/fixedpointnumber_math_remainder-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_remquo-priv.h
+++ b/include/fixedpointnumber_math_remquo-priv.h
@@ -23,7 +23,7 @@
 #include "fixedpointnumber_math.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_round-priv.h
+++ b/include/fixedpointnumber_math_round-priv.h
@@ -22,7 +22,7 @@
 #include "fixedpointnumber.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {

--- a/include/fixedpointnumber_math_signbit-priv.h
+++ b/include/fixedpointnumber_math_signbit-priv.h
@@ -22,7 +22,7 @@
 #include "fixedpointnumber.h"
 
 #ifndef FIXEDPOINTNUMBER_MATH_INTERNAL
-#error Do not include this file directly, ixedpointnumber_math.h instead.
+#error Do not include this file directly, fixedpointnumber_math.h instead.
 #endif
 
 namespace fixedpointnumber {


### PR DESCRIPTION
# Summary

- Resolved typo in error message for internal header include guard

# Details

- `ixedpointnumber_math.h` ➡️ `fixedpointnumber_math.h`

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- N/A

# Notes

- N/A
