### PR TITLE
Resolved invalid conversion from float into long Q fixed_t.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,7 @@ $(DOXYGEN_LATEX): $(DOXYGEN_TARGET_SRCS) $(DOXYFILE_FOR_LATEX) $(DOXYGEN_OUT_DIR
 
 $(DOXYFILE_FOR_LATEX): $(DOXYFILE)
 	@mkdir -p $(dir $(DOXYFILE_FOR_LATEX))
-	sed -e "s/^\([^#]*GENERATE_LATEX *= *\)NO/\1YES/g" $(DOXYFILE) > $@
+	sed -e "s/^\([^#]*GENERATE_LATEX *= *\)NO/\1YES/g" -e "s/^\([^#]*GENERATE_HTML *= *\)YES/\1NO/g" $(DOXYFILE) > $@
 
 pdf: $(DOXYGEN_PDF)
 

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -321,7 +321,10 @@ class fixed_t {
   /// This coefficient will be used
   /// both conversion from floating point type to internal type,
   /// and conversion from internal type to floating point type.
-  constexpr static internal_int_t kCoef = static_cast<internal_int_t>(1) << Q;
+  ///
+  /// @note This must be wider_int_t, not internal_int_t,
+  ///       because of prevention of overflow by left shift
+  constexpr static wider_int_t kCoef = static_cast<internal_int_t>(1) << Q;
 
   /// Convert from some integral type value
   /// to internal integral fixed point type value.

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -314,7 +314,11 @@ class fixed_t {
   internal_int_t fixed_point_;
 
  private:
-  /// Coefficient to convert to internal fixed point value.
+  /// Coefficient to convert from/to floating point type.
+  ///
+  /// This coefficient will be used
+  /// both conversion from floating point type to internal type,
+  /// and conversion from internal type to floating point type.
   constexpr static internal_int_t kCoef = static_cast<internal_int_t>(1) << Q;
 
   /// Convert from some integral type value

--- a/include/fixedpointnumber.h
+++ b/include/fixedpointnumber.h
@@ -37,6 +37,9 @@ namespace fixedpointnumber {
 /// @tparam Q              Bits width for decimal part
 template <typename internal_int_t, std::size_t Q>
 class fixed_t {
+  /// Alias of wider int type than internal_int_t.
+  using wider_int_t = impl::wider_int_t<internal_int_t>;
+
  public:
   /// Alias of internal integer type which holding fixed point number.
   using type = internal_int_t;
@@ -45,8 +48,7 @@ class fixed_t {
   constexpr static std::size_t kBitsWidthOfDecimalPart = Q;
   /// Bits mask of decimal part of this type.
   constexpr static internal_int_t kDecimalPartMask =
-      static_cast<internal_int_t>((impl::wider_int_t<internal_int_t>(1)
-                                   << kBitsWidthOfDecimalPart)
+      static_cast<internal_int_t>((wider_int_t(1) << kBitsWidthOfDecimalPart)
                                   - 1);
   static_assert(kDecimalPartMask > 0,
                 "Can't calculate mask for decimal part.");

--- a/include/fixedpointnumber_conversion-priv.h
+++ b/include/fixedpointnumber_conversion-priv.h
@@ -115,7 +115,6 @@ template <typename SrcType>
 constexpr IntType fixed_t<IntType, Q>::ToInternalType(
     typename std::enable_if<std::is_same<SrcType, const char*>::value,
                             SrcType>::type str) {
-  using wider_int_t = impl::wider_int_t<IntType>;
   return static_cast<IntType>(
       (impl::FromStringToDecimalInt<wider_int_t>(str) << Q)
       / impl::FromStringDecimalCoef<wider_int_t>(str));

--- a/include/fixedpointnumber_string-priv.h
+++ b/include/fixedpointnumber_string-priv.h
@@ -52,7 +52,6 @@ std::string fixed_t<IntType, Q>::ToString() const {
     ss << integral_part
        << '.';
 
-    using wider_int_t = impl::wider_int_t<IntType>;
     wider_int_t decimal_part = wider_int_t(abs_fixed_point) & kDecimalPartMask;
     if (decimal_part != 0) {
       while (decimal_part > 0) {

--- a/test/test_float_long_Q_conversion.cc
+++ b/test/test_float_long_Q_conversion.cc
@@ -1,0 +1,44 @@
+//
+// Copyright 2021 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+
+namespace {
+
+using fixed_t = fixedpointnumber::fixed_t<uint16_t, 16>;
+
+}  // namespace
+
+class FloatLongQFixedConversionTest
+    : public ::testing::TestWithParam<float> {
+};
+
+TEST_P(FloatLongQFixedConversionTest, SimpleConversion) {
+  const float test_value = GetParam();
+  const fixed_t f(test_value);
+
+  EXPECT_FLOAT_EQ(test_value, static_cast<float>(f));
+}
+
+INSTANTIATE_TEST_SUITE_P(Instance0,
+                         FloatLongQFixedConversionTest,
+                         ::testing::Range(0.0f, 1.0f, 0.5f));


### PR DESCRIPTION
# Summary

- Tests for conversion from float into long Q `fixed_t`

# Details

- Tests for conversion from float into long Q `fixed_t`

# Continuous operation guarantee by

- [x] Unit tests
  - [ ] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #206 

# Notes

- N/A
