### PR TITLE
Reduced Doxygen CI time.

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Install graphviz, doxygen, and TeX
       run: |
         sudo apt update
-        sudo apt install -y --no-install-recommends graphviz doxygen texlive-full texlive-latex-extra
+        sudo apt install -y --no-install-recommends graphviz doxygen
+        sudo apt install -y texlive-latex-extra
 
     - name: Make Doxygen documents
       run: |


### PR DESCRIPTION
# Summary

- Reduced Doxygen CI time

# Details

- Reduced Doxygen CI time by using `texlive-latex-extra` only without `texlive-full`

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #205 

# Notes

- N/A
