### PR TITLE
Test overflow causes overwrapping (not saturation).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ CPPCHECK_FLAGS += --language=c++
 CPPCHECK_FLAGS += --std=c++11
 CPPCHECK_FLAGS += --quiet
 CPPCHECK_FLAGS += --enable=all
+CPPCHECK_FLAGS += --inline-suppr
 CPPCHECK_FLAGS += --suppressions-list=$(CPPCHECK_SUPPRESION_LIST_TXT)
 CPPCHECK_FLAGS += --error-exitcode=2
 

--- a/include/fixedpointnumber_limits.h
+++ b/include/fixedpointnumber_limits.h
@@ -125,7 +125,7 @@ class numeric_limits {
 
   /// Get minimum normalized positive value.
   ///
-  /// This is compatible to std::numeric_limits<T>::min()..
+  /// This is compatible to std::numeric_limits<T>::min().
   static constexpr T min() noexcept {
     return T(typename T::type(1), true);
   }

--- a/test/test_arithmetic_add_overflow_overwrap.cc
+++ b/test/test_arithmetic_add_overflow_overwrap.cc
@@ -1,0 +1,51 @@
+//
+// Copyright 2021 Minoru Sekine
+//
+// This file is part of libfixedpointnumber.
+//
+// libfixedpointnumber is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libfixedpointnumber is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with libfixedpointnumber.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <cstdint>
+
+#include "gtest_compat.h"
+
+#include "fixedpointnumber.h"
+#include "fixedpointnumber_limits.h"
+
+template <typename T>
+class AddOverflowIsOverwrappingTest
+    : public ::testing::Test {
+ protected:
+  using fixed_t = T;
+  using fixed_limits = fixedpointnumber::numeric_limits<fixed_t>;
+};
+
+using MyTypes = ::testing::Types<fixedpointnumber::fixed_t<uint8_t, 4>,
+                                 fixedpointnumber::fixed_t<uint16_t, 5>,
+                                 fixedpointnumber::fixed_t<uint32_t, 20>,
+                                 fixedpointnumber::fixed_t<int8_t, 6>,
+                                 fixedpointnumber::fixed_t<int16_t, 10>,
+                                 fixedpointnumber::fixed_t<int32_t, 2>>;
+
+// This strange 3rd argument omission is quick hack
+// for warning with Google Test Framework.
+// See https://github.com/google/googletest/issues/2271#issuecomment-665742471 .
+// cppcheck-suppress syntaxError
+TYPED_TEST_SUITE(AddOverflowIsOverwrappingTest, MyTypes, );  // NOLINT
+
+TYPED_TEST(AddOverflowIsOverwrappingTest, Validate) {
+  const auto max_num = TestFixture::fixed_limits::max();
+  const auto min_num = TestFixture::fixed_limits::min();
+  EXPECT_LT(max_num + min_num, max_num);
+}


### PR DESCRIPTION
# Summary

- Test overflow causes overwrapping (not saturation)

# Details

- Overflow should cause overwrapping (not saturation) for compatibility to C++ build-in types, so confirm it

# Continuous operation guarantee by

- [x] Unit tests
  - [ ] Those tests already exists
  - [x] Those tests are included in this PR
- [ ] Sample program
- [ ] CI

# References

- #209 
- #210 
- #211 

# Notes

- N/A
