### PR TITLE
fix: Doxygen workflow err by legacy actions/upload-artifact (#226)

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -24,7 +24,7 @@ jobs:
           make -k -j doxygen latex pdf
 
       - name: Upload Doxygen documents
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: doc
           path: out/site/Doxygen

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ DOXYGEN_TARGET_SRCS := $(INCLUDE_DIR_HEADER)
 # Targets.
 all: build-all
 
-build-all: build-test build-sample
+build-all: build-test build-sample site
 
 run-all: run-test run-sample
 


### PR DESCRIPTION
# Summary

- Resolved `Doxygen` workflow error by using legacy `actions/upload-artifact@v1`

# Details

- Include `make site` into `make all`
- Replace `actions/upload-artifact@v1` to `actions/upload-artifact@v4`

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #226 

# Notes

- N/A
