### PR TITLE
fix: Error by clang `-Wnan-infinity-disabled`. (#228)

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build and run tests (FreeBSD)
-        uses: vmactions/freebsd-vm@v1.0.7
+        uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
           prepare: pkg install -y googletest gmake

--- a/test/test_numeric_limits_bool_consts.cc
+++ b/test/test_numeric_limits_bool_consts.cc
@@ -65,7 +65,16 @@ TEST(NumericLimitsTest, StaticMemberFunctions) {
   EXPECT_EQ(fixed_t(255.9921875f), limits::max());
   EXPECT_EQ(fixed_t(0.0078125f), limits::epsilon());
   EXPECT_EQ(fixed_t(0.5f), limits::round_error());
-  EXPECT_EQ(fixed_t(0), limits::infinity());
+
+  // No solid expectation for std::numeric_limits::infinity<fixed_t>(),
+  // because std::numeric_limits::has_infinity<fixed_t>() is false.
+  // And this test causes compile-time error
+  // on clang with -Werror,-Wnan-infinity-disabled options.
+  // So disable a test below.
+  // Note: Can't use Google C++ Test Framework's `DISABLED_` prefix here,
+  //       because this is compile-time issue (not runtime issue).
+  // EXPECT_EQ(fixed_t(0), limits::infinity());
+
   EXPECT_EQ(fixed_t(0), limits::quiet_NaN());
   EXPECT_EQ(fixed_t(0), limits::signaling_NaN());
   EXPECT_EQ(fixed_t(0), limits::denorm_min());


### PR DESCRIPTION
# Summary

- chore: Not specify minor version for freebsd-vm

# Details

- chore: Not specify minor version for freebsd-vm

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #228 

# Notes

- N/A
