### PR TITLE
fix: Compiler error on FreeBSD. (#235)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ INCLUDE_DIR_HEADER += $(wildcard $(INCLUDE_DIR)/*.h)
 dummy := $(shell type $(CXX))  # In GNU Make, default CXX should be g++
 ifeq ($(.SHELLSTATUS),0)
   CXX := clang++
+  MY_CXX_MAX_OPTIMIZE_FLAG := -Ofast
   dummy := $(shell type $(CXX))
   ifeq ($(.SHELLSTATUS),0)
     CXX := c++
+    MY_CXX_MAX_OPTIMIZE_FLAG := -O3 -ffast-math
   endif
 endif
 
@@ -65,7 +67,7 @@ ifeq ($(BUILD_TYPE), release)
 ifneq ($(findstring coverage,$(MAKECMDGOALS)),)
 $(error Use BUILD_TYPE=coverage for target "coverage")
 endif
-BUILD_TYPE_CXXFLAGS += -Ofast
+BUILD_TYPE_CXXFLAGS += $(MY_CXX_MAX_OPTIMIZE_FLAG)
 BUILD_TYPE_CXXFLAGS += -DNDEBUG
 else ifeq ($(BUILD_TYPE), debug)
 ifneq ($(findstring coverage,$(MAKECMDGOALS)),)

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ WARNING_CXXFLAGS += -Wno-error=inline
 
 # Build C++ compiler flags for test.
 TEST_CXXFLAGS := $(CXXFLAGS)
-TEST_CXXFLAGS += --std=c++17
+TEST_CXXFLAGS += --std=c++20
 TEST_CXXFLAGS += $(addprefix -I, $(INCLUDE_DIR))
 TEST_CXXFLAGS += $(addprefix -I, $(SYSTEM_INCLUDE_DIRS))
 TEST_CXXFLAGS += $(BUILD_TYPE_CXXFLAGS)


### PR DESCRIPTION
# Summary

- fix: Compiler error on FreeBSD. (#235)

# Details

- `-O` flag deprecation causes an error

# Continuous operation guarantee by

- [ ] Unit tests
  - [ ] Those tests already exists
  - [ ] Those tests are included in this PR
- [ ] Sample program
- [x] CI

# References

- #235

# Notes

- N/A
